### PR TITLE
fix: subproject config & CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,16 +31,6 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        package-path: [
-          'abstractions',
-          'authentication/phpleague',
-          'http/guzzle',
-          'serialization/json',
-          'serialization/text',
-          'serialization/form',
-          'serialization/multipart',
-          'bundle'
-        ]
         php-versions: ['7.4', '8.0', '8.1', '8.2', '8.3']
     steps:
       - name: Checkout
@@ -51,65 +41,34 @@ jobs:
           php-version: ${{ matrix.php-versions }}
           coverage: none
       - name: Install dependencies
-        working-directory: packages/${{ matrix.package-path }}
         run: composer install
+      - name: Monorepo Builder merge dependencies
+        run: ./vendor/bin/monorepo-builder merge
       - name: Run static analysis
-        working-directory: packages/${{ matrix.package-path }}
         run: ./vendor/bin/phpstan
       - name: Run tests without coverage
-        working-directory: packages/${{ matrix.package-path }}
         run: ./vendor/bin/phpunit --no-coverage
-
-  upload-coverage-reports:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        package-path: [
-          'abstractions',
-          'authentication/phpleague',
-          'http/guzzle',
-          'serialization/json',
-          'serialization/text',
-          'serialization/form',
-          'serialization/multipart',
-          'bundle'
-        ]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Setup PHP and Xdebug for Code Coverage report
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '8.3'
-          coverage: xdebug
-      - name: Install dependencies
-        working-directory: packages/${{ matrix.package-path }}
-        run: composer install
-      - name: Run tests with coverage
-        working-directory: packages/${{ matrix.package-path }}
-        run: ./vendor/bin/phpunit --coverage-clover=coverage.xml
-      - name: Fix code coverage paths
-        working-directory: packages/${{ matrix.package-path }}
-        run: |
-          sed -i 's@'$GITHUB_WORKSPACE'@/github/workspace/@g' coverage.xml
-          echo "ARTIFACT_NAME=$(echo ${{ matrix.package-path }} | sed 's/\//-/g')" >> $GITHUB_ENV
-      - name: Upload code coverage report
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage-reports-${{ env.ARTIFACT_NAME}}
-          path: packages/${{ matrix.package-path }}/coverage.xml
 
   code-coverage:
     runs-on: ubuntu-latest
-    needs: upload-coverage-reports
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           # Disabling shallow clones is recommended for improving the relevancy of reporting
           fetch-depth: 0
-      - name: Download code coverage reports
-        uses: actions/download-artifact@v4
+      - name: Setup PHP and Xdebug for Code Coverage report
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          coverage: xdebug
+      - name: Install dependencies
+        run: composer install
+      - name: Run tests with coverage
+        run: ./vendor/bin/phpunit --coverage-clover=coverage.xml
+      - name: Fix code coverage paths
+        run: |
+          sed -i 's@'$GITHUB_WORKSPACE'@/github/workspace/@g' coverage.xml
       - name: SonarCloud Scan
         if: ${{ !github.event.pull_request.head.repo.fork }}
         uses: SonarSource/sonarqube-scan-action@v4

--- a/composer.json
+++ b/composer.json
@@ -8,11 +8,101 @@
             "email": "graphtooling@service.microsoft.com"
         }
     ],
-	"require": {
-		"php": "^7.4 || ^8.0"
-	},
+    "require": {
+        "doctrine/annotations": "^1.13 || ^2.0",
+        "ext-json": "*",
+        "ext-openssl": "*",
+        "ext-zlib": "*",
+        "firebase/php-jwt": "^v6.0.0",
+        "guzzlehttp/guzzle": "^7.4.5",
+        "guzzlehttp/psr7": "^1.6 || ^2",
+        "league/oauth2-client": "^2.6.1",
+        "open-telemetry/sdk": "^1.0.0",
+        "php": "^7.4 || ^8.0",
+        "php-http/promise": "~1.2.0",
+        "psr/http-message": "^1.1 || ^2.0",
+        "ramsey/uuid": "^4.2.3",
+        "stduritemplate/stduritemplate": "^0.0.53 || ^0.0.54 || ^0.0.55 || ^0.0.56 || ^0.0.57 || ^0.0.59 || ^1.0.0 || ^2.0.0"
+    },
     "require-dev": {
-		"symplify/monorepo-builder": "^11.2.22",
-		"phpunit/phpunit": "^9.6.22"
-	}
+        "phpstan/phpstan": "^1.12.16",
+        "phpunit/phpunit": "^9.6.22",
+        "roave/security-advisories": "dev-latest",
+        "symplify/monorepo-builder": "^11.2.22"
+    },
+    "autoload": {
+        "psr-4": {
+            "Microsoft\\Kiota\\Abstractions\\": "packages/abstractions/src/",
+            "Microsoft\\Kiota\\Authentication\\": "packages/authentication/phpleague/src/",
+            "Microsoft\\Kiota\\Bundle\\": "packages/bundle/src/",
+            "Microsoft\\Kiota\\Http\\": "packages/http/guzzle/src/",
+            "Microsoft\\Kiota\\Serialization\\Form\\": "packages/serialization/form/src",
+            "Microsoft\\Kiota\\Serialization\\Json\\": "packages/serialization/json/src",
+            "Microsoft\\Kiota\\Serialization\\Multipart\\": "packages/serialization/multipart/src",
+            "Microsoft\\Kiota\\Serialization\\Text\\": "packages/serialization/text/src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Microsoft\\Kiota\\Abstractions\\Tests\\": "packages/abstractions/tests/",
+            "Microsoft\\Kiota\\Authentication\\Test\\": "packages/authentication/phpleague/tests/",
+            "Microsoft\\Kiota\\Bundle\\Test\\": "packages/bundle/tests/",
+            "Microsoft\\Kiota\\Http\\Test\\": "packages/http/guzzle/tests/",
+            "Microsoft\\Kiota\\Serialization\\Multipart\\Tests\\": "packages/serialization/multipart/tests",
+            "Microsoft\\Kiota\\Serialization\\Tests\\": [
+                "packages/serialization/form/tests",
+                "packages/serialization/json/tests"
+            ],
+            "Microsoft\\Kiota\\Serialization\\Text\\Tests\\": "packages/serialization/text/tests/"
+        }
+    },
+    "repositories": [
+        {
+            "options": {
+                "symlink": false
+            },
+            "type": "path",
+            "url": "packages/abstractions"
+        },
+        {
+            "options": {
+                "symlink": false
+            },
+            "type": "path",
+            "url": "packages/http/guzzle"
+        },
+        {
+            "options": {
+                "symlink": false
+            },
+            "type": "path",
+            "url": "packages/serialization/form"
+        },
+        {
+            "options": {
+                "symlink": false
+            },
+            "type": "path",
+            "url": "packages/serialization/json"
+        },
+        {
+            "options": {
+                "symlink": false
+            },
+            "type": "path",
+            "url": "packages/serialization/multipart"
+        },
+        {
+            "options": {
+                "symlink": false
+            },
+            "type": "path",
+            "url": "packages/serialization/text"
+        }
+    ],
+    "config": {
+        "allow-plugins": {
+            "php-http/discovery": false
+        }
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,64 @@
             "email": "graphtooling@service.microsoft.com"
         }
     ],
+	"repositories": [
+		{
+			"type": "path",
+			"url": "packages/abstractions",
+			"options": {
+				"symlink": false
+			}
+		},
+		{
+			"type": "path",
+			"url": "packages/authentication/phpleague",
+			"options": {
+				"symlink": false
+			}
+		},
+		{
+			"type": "path",
+			"url": "packages/bundle",
+			"options": {
+				"symlink": false
+			}
+		},
+		{
+			"type": "path",
+			"url": "packages/http/guzzle",
+			"options": {
+				"symlink": false
+			}
+		},
+		{
+			"type": "path",
+			"url": "packages/serialization/form",
+			"options": {
+				"symlink": false
+			}
+		},
+		{
+			"type": "path",
+			"url": "packages/serialization/json",
+			"options": {
+				"symlink": false
+			}
+		},
+		{
+			"type": "path",
+			"url": "packages/serialization/multipart",
+			"options": {
+				"symlink": false
+			}
+		},
+		{
+			"type": "path",
+			"url": "packages/serialization/text",
+			"options": {
+				"symlink": false
+			}
+		}
+	],
     "require": {
         "doctrine/annotations": "^1.13 || ^2.0",
         "ext-json": "*",
@@ -30,92 +88,16 @@
         "roave/security-advisories": "dev-latest",
         "symplify/monorepo-builder": "^11.2.22"
     },
-    "repositories": [
-        {
-            "options": {
-                "symlink": false
-            },
-            "type": "path",
-            "url": "abstractions"
-        },
-        {
-            "options": {
-                "symlink": false
-            },
-            "type": "path",
-            "url": "http/guzzle"
-        },
-        {
-            "options": {
-                "symlink": false
-            },
-            "type": "path",
-            "url": "serialization/form"
-        },
-        {
-            "options": {
-                "symlink": false
-            },
-            "type": "path",
-            "url": "serialization/json"
-        },
-        {
-            "options": {
-                "symlink": false
-            },
-            "type": "path",
-            "url": "serialization/multipart"
-        },
-        {
-            "options": {
-                "symlink": false
-            },
-            "type": "path",
-            "url": "serialization/text"
-        },
-        {
-            "options": {
-                "symlink": false
-            },
-            "type": "path",
-            "url": "packages/abstractions"
-        },
-        {
-            "options": {
-                "symlink": false
-            },
-            "type": "path",
-            "url": "packages/http/guzzle"
-        },
-        {
-            "options": {
-                "symlink": false
-            },
-            "type": "path",
-            "url": "packages/serialization/form"
-        },
-        {
-            "options": {
-                "symlink": false
-            },
-            "type": "path",
-            "url": "packages/serialization/json"
-        },
-        {
-            "options": {
-                "symlink": false
-            },
-            "type": "path",
-            "url": "packages/serialization/multipart"
-        },
-        {
-            "options": {
-                "symlink": false
-            },
-            "type": "path",
-            "url": "packages/serialization/text"
-        }
-    ],
+    "replace": {
+        "microsoft/kiota-abstractions": "self.version",
+        "microsoft/kiota-authentication-phpleague": "self.version",
+        "microsoft/kiota-bundle": "self.version",
+        "microsoft/kiota-http-guzzle": "self.version",
+        "microsoft/kiota-serialization-form": "self.version",
+        "microsoft/kiota-serialization-json": "self.version",
+        "microsoft/kiota-serialization-multipart": "self.version",
+        "microsoft/kiota-serialization-text": "self.version"
+    },
     "autoload": {
         "psr-4": {
             "Microsoft\\Kiota\\Abstractions\\": "packages/abstractions/src/",
@@ -144,15 +126,5 @@
         "allow-plugins": {
             "php-http/discovery": false
         }
-    },
-    "replace": {
-        "microsoft/kiota-abstractions": "self.version",
-        "microsoft/kiota-authentication-phpleague": "self.version",
-        "microsoft/kiota-bundle": "self.version",
-        "microsoft/kiota-http-guzzle": "self.version",
-        "microsoft/kiota-serialization-form": "self.version",
-        "microsoft/kiota-serialization-json": "self.version",
-        "microsoft/kiota-serialization-multipart": "self.version",
-        "microsoft/kiota-serialization-text": "self.version"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -30,33 +30,49 @@
         "roave/security-advisories": "dev-latest",
         "symplify/monorepo-builder": "^11.2.22"
     },
-    "autoload": {
-        "psr-4": {
-            "Microsoft\\Kiota\\Abstractions\\": "packages/abstractions/src/",
-            "Microsoft\\Kiota\\Authentication\\": "packages/authentication/phpleague/src/",
-            "Microsoft\\Kiota\\Bundle\\": "packages/bundle/src/",
-            "Microsoft\\Kiota\\Http\\": "packages/http/guzzle/src/",
-            "Microsoft\\Kiota\\Serialization\\Form\\": "packages/serialization/form/src",
-            "Microsoft\\Kiota\\Serialization\\Json\\": "packages/serialization/json/src",
-            "Microsoft\\Kiota\\Serialization\\Multipart\\": "packages/serialization/multipart/src",
-            "Microsoft\\Kiota\\Serialization\\Text\\": "packages/serialization/text/src/"
-        }
-    },
-    "autoload-dev": {
-        "psr-4": {
-            "Microsoft\\Kiota\\Abstractions\\Tests\\": "packages/abstractions/tests/",
-            "Microsoft\\Kiota\\Authentication\\Test\\": "packages/authentication/phpleague/tests/",
-            "Microsoft\\Kiota\\Bundle\\Test\\": "packages/bundle/tests/",
-            "Microsoft\\Kiota\\Http\\Test\\": "packages/http/guzzle/tests/",
-            "Microsoft\\Kiota\\Serialization\\Multipart\\Tests\\": "packages/serialization/multipart/tests",
-            "Microsoft\\Kiota\\Serialization\\Tests\\": [
-                "packages/serialization/form/tests",
-                "packages/serialization/json/tests"
-            ],
-            "Microsoft\\Kiota\\Serialization\\Text\\Tests\\": "packages/serialization/text/tests/"
-        }
-    },
     "repositories": [
+        {
+            "options": {
+                "symlink": false
+            },
+            "type": "path",
+            "url": "abstractions"
+        },
+        {
+            "options": {
+                "symlink": false
+            },
+            "type": "path",
+            "url": "http/guzzle"
+        },
+        {
+            "options": {
+                "symlink": false
+            },
+            "type": "path",
+            "url": "serialization/form"
+        },
+        {
+            "options": {
+                "symlink": false
+            },
+            "type": "path",
+            "url": "serialization/json"
+        },
+        {
+            "options": {
+                "symlink": false
+            },
+            "type": "path",
+            "url": "serialization/multipart"
+        },
+        {
+            "options": {
+                "symlink": false
+            },
+            "type": "path",
+            "url": "serialization/text"
+        },
         {
             "options": {
                 "symlink": false
@@ -100,9 +116,43 @@
             "url": "packages/serialization/text"
         }
     ],
+    "autoload": {
+        "psr-4": {
+            "Microsoft\\Kiota\\Abstractions\\": "packages/abstractions/src/",
+            "Microsoft\\Kiota\\Authentication\\": "packages/authentication/phpleague/src/",
+            "Microsoft\\Kiota\\Bundle\\": "packages/bundle/src/",
+            "Microsoft\\Kiota\\Http\\": "packages/http/guzzle/src/",
+            "Microsoft\\Kiota\\Serialization\\Form\\": "packages/serialization/form/src",
+            "Microsoft\\Kiota\\Serialization\\Json\\": "packages/serialization/json/src",
+            "Microsoft\\Kiota\\Serialization\\Multipart\\": "packages/serialization/multipart/src",
+            "Microsoft\\Kiota\\Serialization\\Text\\": "packages/serialization/text/src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Microsoft\\Kiota\\Abstractions\\Tests\\": "packages/abstractions/tests/",
+            "Microsoft\\Kiota\\Authentication\\Test\\": "packages/authentication/phpleague/tests/",
+            "Microsoft\\Kiota\\Bundle\\Test\\": "packages/bundle/tests/",
+            "Microsoft\\Kiota\\Http\\Test\\": "packages/http/guzzle/tests/",
+            "Microsoft\\Kiota\\Serialization\\Form\\Tests\\": "packages/serialization/form/tests",
+            "Microsoft\\Kiota\\Serialization\\Json\\Tests\\": "packages/serialization/json/tests",
+            "Microsoft\\Kiota\\Serialization\\Multipart\\Tests\\": "packages/serialization/multipart/tests",
+            "Microsoft\\Kiota\\Serialization\\Text\\Tests\\": "packages/serialization/text/tests/"
+        }
+    },
     "config": {
         "allow-plugins": {
             "php-http/discovery": false
         }
+    },
+    "replace": {
+        "microsoft/kiota-abstractions": "self.version",
+        "microsoft/kiota-authentication-phpleague": "self.version",
+        "microsoft/kiota-bundle": "self.version",
+        "microsoft/kiota-http-guzzle": "self.version",
+        "microsoft/kiota-serialization-form": "self.version",
+        "microsoft/kiota-serialization-json": "self.version",
+        "microsoft/kiota-serialization-multipart": "self.version",
+        "microsoft/kiota-serialization-text": "self.version"
     }
 }

--- a/monorepo-builder.php
+++ b/monorepo-builder.php
@@ -1,5 +1,7 @@
 <?php
 
+use Symplify\MonorepoBuilder\ComposerJsonManipulator\ValueObject\ComposerJsonSection;
+use Symplify\MonorepoBuilder\ValueObject\Option;
 use Symplify\MonorepoBuilder\Config\MBConfig;
 
 require_once __DIR__ . '/vendor/autoload.php';
@@ -7,6 +9,15 @@ require_once __DIR__ . '/vendor/autoload.php';
 return static function (MBConfig $mbConfig): void {
     // where are the packages located?
     $mbConfig->packageDirectories([
-        __DIR__ . '/packages',
+        __DIR__ . '/packages/',
+    ]);
+    $mbConfig->dataToRemove([
+        ComposerJsonSection::MINIMUM_STABILITY => Option::REMOVE_COMPLETELY,
+        ComposerJsonSection::REPOSITORIES => [
+            Option::REMOVE_COMPLETELY,
+        ],
+        ComposerJsonSection::REPLACE => [
+            Option::REMOVE_COMPLETELY,
+        ]
     ]);
 };

--- a/packages/bundle/composer.json
+++ b/packages/bundle/composer.json
@@ -20,50 +20,6 @@
 			"Microsoft\\Kiota\\Bundle\\Test\\": "tests/"
 		}
 	},
-	"repositories": [
-		{
-			"type": "path",
-			"url": "../abstractions",
-			"options": {
-				"symlink": false
-			}
-		},
-		{
-			"type": "path",
-			"url": "../http/guzzle",
-			"options": {
-				"symlink": false
-			}
-		},
-		{
-			"type": "path",
-			"url": "../serialization/json",
-			"options": {
-				"symlink": false
-			}
-		},
-		{
-			"type": "path",
-			"url": "../serialization/form",
-			"options": {
-				"symlink": false
-			}
-		},
-		{
-			"type": "path",
-			"url": "../serialization/multipart",
-			"options": {
-				"symlink": false
-			}
-		},
-		{
-			"type": "path",
-			"url": "../serialization/text",
-			"options": {
-				"symlink": false
-			}
-		}
-	],
     "require": {
 		"php": "^7.4 || ^8.0",
 		"microsoft/kiota-abstractions": "^1.4.0",

--- a/packages/http/guzzle/composer.json
+++ b/packages/http/guzzle/composer.json
@@ -3,15 +3,6 @@
     "description": "Kiota HTTP Request Adapter implementation",
 	"version": "1.3.1",
     "type": "library",
-	"repositories": [
-		{
-			"type": "path",
-			"url": "../../abstractions",
-			"options": {
-				"symlink": false
-			}
-		}
-	],
 	"require": {
 		"php": "^7.4 || ^8.0",
 		"guzzlehttp/guzzle": "^7.4.5",

--- a/packages/serialization/form/composer.json
+++ b/packages/serialization/form/composer.json
@@ -17,7 +17,7 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Microsoft\\Kiota\\Serialization\\Tests\\": "tests"
+            "Microsoft\\Kiota\\Serialization\\Form\\Tests\\": "tests"
         }
     },
     "repositories": [

--- a/packages/serialization/form/composer.json
+++ b/packages/serialization/form/composer.json
@@ -20,15 +20,6 @@
             "Microsoft\\Kiota\\Serialization\\Form\\Tests\\": "tests"
         }
     },
-    "repositories": [
-        {
-            "type": "path",
-            "url": "../../abstractions",
-            "options": {
-                    "symlink": false
-            }
-        }
-    ],
     "require": {
         "microsoft/kiota-abstractions": "^1.4.0",
         "guzzlehttp/psr7": "^1.6 || ^2",

--- a/packages/serialization/form/tests/FormParseNodeFactoryTest.php
+++ b/packages/serialization/form/tests/FormParseNodeFactoryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Microsoft\Kiota\Serialization\Tests;
+namespace Microsoft\Kiota\Serialization\Form\Tests;
 
 use GuzzleHttp\Psr7\Utils;
 use Microsoft\Kiota\Abstractions\Serialization\AdditionalDataHolder;

--- a/packages/serialization/form/tests/FormParseNodeTest.php
+++ b/packages/serialization/form/tests/FormParseNodeTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Microsoft\Kiota\Serialization\Tests;
+namespace Microsoft\Kiota\Serialization\Form\Tests;
 
 use DateTime;
 use DateTimeInterface;
@@ -12,9 +12,9 @@ use Microsoft\Kiota\Abstractions\Types\Date;
 use Microsoft\Kiota\Abstractions\Types\Time;
 use Microsoft\Kiota\Serialization\Form\FormParseNode;
 use Microsoft\Kiota\Serialization\Form\FormParseNodeFactory;
-use Microsoft\Kiota\Serialization\Tests\Samples\BioContentType;
-use Microsoft\Kiota\Serialization\Tests\Samples\MaritalStatus;
-use Microsoft\Kiota\Serialization\Tests\Samples\Person;
+use Microsoft\Kiota\Serialization\Form\Tests\Samples\BioContentType;
+use Microsoft\Kiota\Serialization\Form\Tests\Samples\MaritalStatus;
+use Microsoft\Kiota\Serialization\Form\Tests\Samples\Person;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\StreamInterface;
 

--- a/packages/serialization/form/tests/FormSerializationWriterTest.php
+++ b/packages/serialization/form/tests/FormSerializationWriterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Microsoft\Kiota\Serialization\Tests;
+namespace Microsoft\Kiota\Serialization\Form\Tests;
 
 use DateInterval;
 use GuzzleHttp\Psr7\Utils;
@@ -9,9 +9,9 @@ use Microsoft\Kiota\Abstractions\Serialization\SerializationWriter;
 use Microsoft\Kiota\Abstractions\Types\Date;
 use Microsoft\Kiota\Abstractions\Types\Time;
 use Microsoft\Kiota\Serialization\Form\FormSerializationWriter;
-use Microsoft\Kiota\Serialization\Tests\Samples\Address;
-use Microsoft\Kiota\Serialization\Tests\Samples\MaritalStatus;
-use Microsoft\Kiota\Serialization\Tests\Samples\Person;
+use Microsoft\Kiota\Serialization\Form\Tests\Samples\Address;
+use Microsoft\Kiota\Serialization\Form\Tests\Samples\MaritalStatus;
+use Microsoft\Kiota\Serialization\Form\Tests\Samples\Person;
 use PHPUnit\Framework\TestCase;
 
 class FormSerializationWriterTest extends TestCase

--- a/packages/serialization/form/tests/Samples/Address.php
+++ b/packages/serialization/form/tests/Samples/Address.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Microsoft\Kiota\Serialization\Tests\Samples;
+namespace Microsoft\Kiota\Serialization\Form\Tests\Samples;
 
 use Microsoft\Kiota\Abstractions\Serialization\AdditionalDataHolder;
 use Microsoft\Kiota\Abstractions\Serialization\Parsable;

--- a/packages/serialization/form/tests/Samples/BioContentType.php
+++ b/packages/serialization/form/tests/Samples/BioContentType.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Microsoft\Kiota\Serialization\Tests\Samples;
+namespace Microsoft\Kiota\Serialization\Form\Tests\Samples;
 
 use Microsoft\Kiota\Abstractions\Enum;
 

--- a/packages/serialization/form/tests/Samples/MaritalStatus.php
+++ b/packages/serialization/form/tests/Samples/MaritalStatus.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Microsoft\Kiota\Serialization\Tests\Samples;
+namespace Microsoft\Kiota\Serialization\Form\Tests\Samples;
 
 use Microsoft\Kiota\Abstractions\Enum;
 

--- a/packages/serialization/form/tests/Samples/Person.php
+++ b/packages/serialization/form/tests/Samples/Person.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Microsoft\Kiota\Serialization\Tests\Samples;
+namespace Microsoft\Kiota\Serialization\Form\Tests\Samples;
 
 use Microsoft\Kiota\Abstractions\Serialization\AdditionalDataHolder;
 use Microsoft\Kiota\Abstractions\Serialization\Parsable;
@@ -18,6 +18,7 @@ class Person implements Parsable, AdditionalDataHolder
 
     private ?MaritalStatus $maritalStatus = null;
 
+    private ?Address $address = null;
 
     /** @var BioContentType[]|null  */
     private ?array $bioContentType = null;

--- a/packages/serialization/json/composer.json
+++ b/packages/serialization/json/composer.json
@@ -17,7 +17,7 @@
     },
     "autoload-dev": {
 		"psr-4": {
-			"Microsoft\\Kiota\\Serialization\\Tests\\": "tests"
+			"Microsoft\\Kiota\\Serialization\\Json\\Tests\\": "tests"
 		}
     },
 	"repositories": [

--- a/packages/serialization/json/composer.json
+++ b/packages/serialization/json/composer.json
@@ -20,15 +20,6 @@
 			"Microsoft\\Kiota\\Serialization\\Json\\Tests\\": "tests"
 		}
     },
-	"repositories": [
-        {
-            "type": "path",
-            "url": "../../abstractions",
-            "options": {
-                    "symlink": false
-            }
-        }
-    ],
     "require": {
         "microsoft/kiota-abstractions": "^1.4.0",
         "guzzlehttp/psr7": "^1.6 || ^2",

--- a/packages/serialization/json/tests/JsonParseNodeFactoryTest.php
+++ b/packages/serialization/json/tests/JsonParseNodeFactoryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Microsoft\Kiota\Serialization\Tests;
+namespace Microsoft\Kiota\Serialization\Json\Tests;
 
 use GuzzleHttp\Psr7\Utils;
 use InvalidArgumentException;

--- a/packages/serialization/json/tests/JsonParseNodeTest.php
+++ b/packages/serialization/json/tests/JsonParseNodeTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Microsoft\Kiota\Serialization\Tests;
+namespace Microsoft\Kiota\Serialization\Json\Tests;
 
 use DateInterval;
 use DateTime;
@@ -13,9 +13,9 @@ use Microsoft\Kiota\Abstractions\Types\Date;
 use Microsoft\Kiota\Abstractions\Types\Time;
 use Microsoft\Kiota\Serialization\Json\JsonParseNode;
 use Microsoft\Kiota\Serialization\Json\JsonParseNodeFactory;
-use Microsoft\Kiota\Serialization\Tests\Samples\Address;
-use Microsoft\Kiota\Serialization\Tests\Samples\MaritalStatus;
-use Microsoft\Kiota\Serialization\Tests\Samples\Person;
+use Microsoft\Kiota\Serialization\Json\Tests\Samples\Address;
+use Microsoft\Kiota\Serialization\Json\Tests\Samples\MaritalStatus;
+use Microsoft\Kiota\Serialization\Json\Tests\Samples\Person;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\StreamInterface;
 

--- a/packages/serialization/json/tests/JsonSerializationWriterFactoryTest.php
+++ b/packages/serialization/json/tests/JsonSerializationWriterFactoryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Microsoft\Kiota\Serialization\Tests;
+namespace Microsoft\Kiota\Serialization\Json\Tests;
 
 use InvalidArgumentException;
 use Microsoft\Kiota\Abstractions\Serialization\SerializationWriterFactory;

--- a/packages/serialization/json/tests/JsonSerializationWriterTest.php
+++ b/packages/serialization/json/tests/JsonSerializationWriterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Microsoft\Kiota\Serialization\Tests;
+namespace Microsoft\Kiota\Serialization\Json\Tests;
 
 use DateInterval;
 use GuzzleHttp\Psr7\Utils;
@@ -11,9 +11,9 @@ use Microsoft\Kiota\Abstractions\Serialization\SerializationWriter;
 use Microsoft\Kiota\Abstractions\Types\Date;
 use Microsoft\Kiota\Abstractions\Types\Time;
 use Microsoft\Kiota\Serialization\Json\JsonSerializationWriter;
-use Microsoft\Kiota\Serialization\Tests\Samples\Address;
-use Microsoft\Kiota\Serialization\Tests\Samples\MaritalStatus;
-use Microsoft\Kiota\Serialization\Tests\Samples\Person;
+use Microsoft\Kiota\Serialization\Json\Tests\Samples\Address;
+use Microsoft\Kiota\Serialization\Json\Tests\Samples\MaritalStatus;
+use Microsoft\Kiota\Serialization\Json\Tests\Samples\Person;
 use PHPUnit\Framework\TestCase;
 
 class JsonSerializationWriterTest extends TestCase

--- a/packages/serialization/json/tests/Samples/Address.php
+++ b/packages/serialization/json/tests/Samples/Address.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Microsoft\Kiota\Serialization\Tests\Samples;
+namespace Microsoft\Kiota\Serialization\Json\Tests\Samples;
 
 use Microsoft\Kiota\Abstractions\Serialization\AdditionalDataHolder;
 use Microsoft\Kiota\Abstractions\Serialization\Parsable;

--- a/packages/serialization/json/tests/Samples/MaritalStatus.php
+++ b/packages/serialization/json/tests/Samples/MaritalStatus.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Microsoft\Kiota\Serialization\Tests\Samples;
+namespace Microsoft\Kiota\Serialization\Json\Tests\Samples;
 
 use Microsoft\Kiota\Abstractions\Enum;
 

--- a/packages/serialization/json/tests/Samples/Person.php
+++ b/packages/serialization/json/tests/Samples/Person.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Microsoft\Kiota\Serialization\Tests\Samples;
+namespace Microsoft\Kiota\Serialization\Json\Tests\Samples;
 
 use Microsoft\Kiota\Abstractions\Serialization\AdditionalDataHolder;
 use Microsoft\Kiota\Abstractions\Serialization\Parsable;

--- a/packages/serialization/multipart/composer.json
+++ b/packages/serialization/multipart/composer.json
@@ -20,15 +20,6 @@
             "Microsoft\\Kiota\\Serialization\\Multipart\\Tests\\": "tests"
         }
     },
-    "repositories": [
-		{
-			"type": "path",
-			"url": "../../abstractions",
-			"options": {
-							"symlink": false
-			}
-		}
-    ],
     "require": {
         "microsoft/kiota-abstractions": "^1.4.0",
         "guzzlehttp/psr7": "^1.6 || ^2",

--- a/packages/serialization/text/composer.json
+++ b/packages/serialization/text/composer.json
@@ -10,15 +10,6 @@
             "email": "graphtooling@service.microsoft.com"
         }
     ],
-	"repositories": [
-        {
-            "type": "path",
-            "url": "../../abstractions",
-            "options": {
-                    "symlink": false
-            }
-        }
-    ],
     "require": {
 		"php": "^7.4 || ^8.0",
 		"microsoft/kiota-abstractions": "^1.4.0",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,19 @@
+parameters:
+    level: 9
+    polluteScopeWithAlwaysIterableForeach: false
+    polluteScopeWithLoopInitialAssignments: false
+    paths:
+        - packages/abstractions/src
+        - packages/authentication/phpleague/src
+        - packages/http/guzzle/src
+        - packages/bundle/src
+        - packages/serialization/json/src
+        - packages/serialization/form/src
+        - packages/serialization/text/src
+        - packages/serialization/multipart/src
+    ignoreErrors:
+        - '/^Parameter #1 \$[A-Za-z_0-9]+ of function is_subclass_of expects object\|string, mixed given.$/'
+        - '/^Parameter #1 \$[A-Za-z_0-9]+ of function strval expects bool\|float\|int\|resource\|string\|null, mixed given.$/'
+        - '/^Parameter #1 \$[A-Za-z_0-9]+ of function intval expects array\|bool\|float\|int\|resource\|string\|null, mixed given.$/'
+        - '/^Parameter #1 \$[A-Za-z_0-9]+ of function (strval|intval|floatval) expects (array\||)bool\|float\|int\|resource\|string\|null, mixed given.$/'
+

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit colors="true" bootstrap="vendor/autoload.php">
+    <testsuites>
+        <testsuite name="Kiota Abstractions Tests">
+            <directory>packages/abstractions/tests</directory>
+        </testsuite>
+        <testsuite name="Kiota HTTP Guzzle Tests">
+            <directory>packages/http/guzzle/tests</directory>
+        </testsuite>
+        <testsuite name="Kiota PHP League Authentication Tests">
+            <directory>packages/authentication/phpleague/tests</directory>
+        </testsuite>
+        <testsuite name="Kiota Bundle Tests">
+            <directory>packages/bundle/tests</directory>
+        </testsuite>
+        <testsuite name="Kiota Serialization Form Tests">
+            <directory>packages/serialization/form/tests</directory>
+        </testsuite>
+        <testsuite name="Kiota Serialization Json Tests">
+            <directory>packages/serialization/json/tests</directory>
+        </testsuite>
+        <testsuite name="Kiota Serialization Text Tests">
+            <directory>packages/serialization/text/tests</directory>
+        </testsuite>
+        <testsuite name="Kiota Serialization Multipart Tests">
+            <directory>packages/serialization/multipart/tests</directory>
+        </testsuite>
+    </testsuites>
+    <coverage pathCoverage="true">
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+        <exclude>
+            <file>packages/abstractions/src/RequestOption.php</file>
+            <file>packages/abstractions/src/ResponseHandler.php</file>
+            <file>packages/abstractions/src/RequestAdapter.php</file>
+            <file>packages/abstractions/src/serialization/AdditionalDataHolder.php</file>
+            <file>packages/abstractions/src/serialization/Parsable.php</file>
+            <file>packages/abstractions/src/serialization/ParsableFactory.php</file>
+            <file>packages/abstractions/src/serialization/ParseNode.php</file>
+            <file>src/serialization/ParseNodeFactory.php</file>
+            <file>packages/abstractions/src/serialization/SerializationWriter.php</file>
+            <file>packages/abstractions/src/serialization/SerializationWriterFactory.php</file>
+        </exclude>
+        <report>
+            <html outputDirectory="coverage"/>
+        </report>
+    </coverage>
+    <php>
+        <ini name="memory_limit" value="500M" />
+    </php>
+</phpunit>


### PR DESCRIPTION
- Uses `./vendor/bin/monorepo-builder merge` to merge dependencies into root `composer.json` file
- Removes local repository paths from sub-projects in favour of local repository paths in the mono-repo configuration. Local repository paths in sub-projects would cause failures due to non-existent paths after splitting changes to individual repos
- Fixes namespaces in JSON and form serialization tests packages
- Adds central PHPUnit and PHPStan config files to enable running CI against mono-repo root

part of https://github.com/microsoft/kiota-abstractions-php/issues/156