### PR TITLE
chore: boostrap release pipeline

### DIFF
--- a/.azure-pipelines/split-packages.yml
+++ b/.azure-pipelines/split-packages.yml
@@ -1,0 +1,27 @@
+trigger:
+  tags:
+    include:
+      - 'v*'
+
+pr: none
+
+resources:
+  repositories:
+    - repository: 1ESPipelineTemplates
+      type: git
+      name: 1ESPipelineTemplates/1ESPipelineTemplates
+      ref: refs/tags/release
+
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
+  parameters:
+    pool:
+      name: 1es-ubuntu-latest-m
+      stages:
+      - stage: split packages
+        jobs:
+        - job: packages-split
+          steps:
+          - checkout: self
+            persistCredentials: false
+            fetchDepth: 0


### PR DESCRIPTION
Current Azure setup does not allow creating a pipeline from a branch other than main branch.

This boostraps a release pipeline for onboarding to ADO.