### PR TITLE
chore: add gitattributes config for form and multipart serialization

### DIFF
--- a/packages/serialization/form/.gitattributes
+++ b/packages/serialization/form/.gitattributes
@@ -1,0 +1,12 @@
+* text=auto eol=lf
+*.{png,jpg,jpeg,gif,webp,woff,woff2} binary
+/coverage export-ignore
+/docs export-ignore
+/vendor export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+/.github export-ignore
+/tests export-ignore
+phpstan.neon export-ignore
+phpunit.xml export-ignore
+sonar-project.properties export-ignore

--- a/packages/serialization/multipart/.gitattributes
+++ b/packages/serialization/multipart/.gitattributes
@@ -1,0 +1,12 @@
+* text=auto eol=lf
+*.{png,jpg,jpeg,gif,webp,woff,woff2} binary
+/coverage export-ignore
+/docs export-ignore
+/vendor export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+/.github export-ignore
+/tests export-ignore
+phpstan.neon export-ignore
+phpunit.xml export-ignore
+sonar-project.properties export-ignore


### PR DESCRIPTION
This config prevents shipping `tests/` and other non-essential files to customers during the packaging process done via `git archive`

part of https://github.com/microsoft/kiota-php/issues/21