### PR TITLE
Fix create-release and pr-checks workflows

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Kiota PHP is a mono-repo containing source code for the following packages:
 - ['microsoft/kiota-abstractions'](https://packagist.org/packages/microsoft/kiota-abstractions)
 - ['microsoft/kiota-http-guzzle'](https://packagist.org/packages/microsoft/kiota-http-guzzle)
 - ['microsoft/kiota-authentication-phpleague'](https://packagist.org/packages/microsoft/kiota-authentication-phpleague)
-- ['microsoft/kiota-bundle']()
+- ['microsoft/kiota-bundle'](https://packagist.org/packages/microsoft/kiota-bundle)
 - ['microsoft/kiota-serialization-multipart'](https://packagist.org/packages/microsoft/kiota-serialization-multipart)
 - ['microsoft/kiota-serialization-text'](https://packagist.org/packages/microsoft/kiota-serialization-text)
 - ['microsoft/kiota-serialization-json'](https://packagist.org/packages/microsoft/kiota-serialization-json)

--- a/README.md
+++ b/README.md
@@ -10,19 +10,30 @@ To learn more about Kiota, visit the [Kiota repository](https://github.com/micro
 
 ## Libraries
 
-| Library                                                                   | PyPi Release                                                                                                                                        | Changelog                                                      |
+| Library                                                                   | Packagist Release                                                                                                                                        | Changelog                                                      |
 |---------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------|
 | [Abstractions](./packages/abstractions/README.md)                         | [![Latest Stable Version](https://poser.pugx.org/microsoft/kiota-abstractions/version)](https://packagist.org/packages/microsoft/kiota-abstractions)                 | [Changelog](./packages/abstractions/CHANGELOG.md)              |
-| [Authentication - PHPLeague](./packages/authentication/phpleague/README.md)       | [![Latest Stable Version](https://poser.pugx.org/microsoft/kiota-authentication-phpleague/version)](https://packagist.org/packages/microsoft/kiota-authentication-phpleague) | [Changelog](./packages/authentication/phpleague/CHANGELOG.md)      |
+| [Authentication - PhpLeague](./packages/authentication/phpleague/README.md)       | [![Latest Stable Version](https://poser.pugx.org/microsoft/kiota-authentication-phpleague/version)](https://packagist.org/packages/microsoft/kiota-authentication-phpleague) | [Changelog](./packages/authentication/phpleague/CHANGELOG.md)      |
 | [Http - Guzzle](./packages/http/guzzle/README.md)               | [![Latest Stable Version](https://poser.pugx.org/microsoft/kiota-http-guzzle/version)](https://packagist.org/packages/microsoft/kiota-http-guzzle)                                 | [Changelog](./packages/http/guzzle/CHANGELOG.md)                |
-| [Serialization - JSON](./packages/serialization/json/README.md)           | [![Latest Stable Version](https://poser.pugx.org/microsoft/kiota-serialization-json/version)](https://packagist.org/packages/microsoft/kiota-serialization-json)     | [Changelog](./packages/serialization/json/CHANGELOG.md)        |
-| [Serialization - FORM](./packages/serialization/form/README.md)           | [![Latest Stable Version](http://poser.pugx.org/microsoft/kiota-serialization-form/version)](https://packagist.org/packages/microsoft/kiota-serialization-form)      | [Changelog](./packages/serialization/form/CHANGELOG.md)        |
-| [Serialization - TEXT](./packages/serialization/text/README.md)           | [![Latest Stable Version](http://poser.pugx.org/microsoft/kiota-serialization-text/version)](https://packagist.org/packages/microsoft/kiota-serialization-text)     | [Changelog](./packages/serialization/text/CHANGELOG.md)        |
-| [Serialization - MULTIPART](./packages/serialization/multipart/README.md) | [![Latest Stable Version](https://poser.pugx.org/microsoft/kiota-serialization-multipart/version)](https://packagist.org/packages/microsoft/kiota-serialization-json)         | [Changelog](./packages/serialization/multipart/CHANGELOG.md)   |
+| [Serialization - Json](./packages/serialization/json/README.md)           | [![Latest Stable Version](https://poser.pugx.org/microsoft/kiota-serialization-json/version)](https://packagist.org/packages/microsoft/kiota-serialization-json)     | [Changelog](./packages/serialization/json/CHANGELOG.md)        |
+| [Serialization - Form](./packages/serialization/form/README.md)           | [![Latest Stable Version](https://poser.pugx.org/microsoft/kiota-serialization-form/version)](https://packagist.org/packages/microsoft/kiota-serialization-form)      | [Changelog](./packages/serialization/form/CHANGELOG.md)        |
+| [Serialization - Text](./packages/serialization/text/README.md)           | [![Latest Stable Version](https://poser.pugx.org/microsoft/kiota-serialization-text/version)](https://packagist.org/packages/microsoft/kiota-serialization-text)     | [Changelog](./packages/serialization/text/CHANGELOG.md)        |
+| [Serialization - Multipart](./packages/serialization/multipart/README.md) | [![Latest Stable Version](https://poser.pugx.org/microsoft/kiota-serialization-multipart/version)](https://packagist.org/packages/microsoft/kiota-serialization-multipart)         | [Changelog](./packages/serialization/multipart/CHANGELOG.md)   |
 | [Bundle](./packages/bundle/README.md)                                     | [![Latest Stable Version](https://poser.pugx.org/microsoft/kiota-bundle/version)](https://packagist.org/packages/microsoft/kiota-bundle)                             | [Changelog](./packages/bundle/CHANGELOG.md)   |
 
 
 ## Contributing
+This project welcomes contributions and suggestions.  Most contributions require you to agree to a
+Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
+the rights to use your contribution. For details, visit https://cla.opensource.microsoft.com.
+
+When you submit a pull request, a CLA bot will automatically determine whether you need to provide
+a CLA and decorate the PR appropriately (e.g., status check, comment). Simply follow the instructions
+provided by the bot. You will only need to do this once across all repos using our CLA.
+
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
+contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
 
 Please read our [Contributing](./CONTRIBUTING.md) guidelines to begin contributing to this repository.
 

--- a/packages/abstractions/.github/workflows/create-release.yml
+++ b/packages/abstractions/.github/workflows/create-release.yml
@@ -21,6 +21,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Get lib version and set environment variable
+      id: get-version
       run: |
         VERSION=$(grep 'VERSION' src/Constants.php |  grep -oE '[0-9]+\.[0-9]+\.([0-9]+|[0-9]+-[a-z]+)')
         echo "VERSION=$VERSION" >> $GITHUB_ENV

--- a/packages/authentication/phpleague/.github/workflows/create-release.yml
+++ b/packages/authentication/phpleague/.github/workflows/create-release.yml
@@ -21,6 +21,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Get lib version and set environment variable
+      id: get-version
       run: |
         VERSION=$(grep 'VERSION' src/Constants.php |  grep -oE '[0-9]+\.[0-9]+\.([0-9]+|[0-9]+-[a-z]+)')
         echo "VERSION=$VERSION" >> $GITHUB_ENV

--- a/packages/authentication/phpleague/.github/workflows/rerun-pr-checks.yml
+++ b/packages/authentication/phpleague/.github/workflows/rerun-pr-checks.yml
@@ -26,9 +26,12 @@ jobs:
 
     # Kiota Abstractions needs to be released first for PR checks to pass
     # We delay before re-running checks to ensure Abstractions is already released
+    # We sleep before re-running checks to ensure the status checks have time to update (https://github.com/cli/cli/pull/2279#discussion_r513610296)
+    # Fetching checks on recently created branches can return a false "no required checks reported on the ... branch" error
     - name: Delay and re-run checks
       run: |
-        needsRerun=$(gh pr checks $PR_URL --required --json bucket --jq '.[] | select(.bucket != "pass") | .bucket')
+        sleep 30
+        needsRerun=$(gh pr checks $PR_URL --required --watch --json bucket --jq '.[] | select(.bucket != "pass") | .bucket')
         if [[ $needsRerun ]]; then
           sleep 300
           gh pr checks $PR_URL --required --json link --jq .[].link | grep -oP '/runs/\K\d+' | { read runId; gh run rerun $runId; }

--- a/packages/bundle/.github/workflows/create-release.yml
+++ b/packages/bundle/.github/workflows/create-release.yml
@@ -21,6 +21,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Get lib version and set environment variable
+      id: get-version
       run: |
         VERSION=$(grep 'VERSION' src/Constants.php |  grep -oE '[0-9]+\.[0-9]+\.([0-9]+|[0-9]+-[a-z]+)')
         echo "VERSION=$VERSION" >> $GITHUB_ENV

--- a/packages/bundle/.github/workflows/rerun-pr-checks.yml
+++ b/packages/bundle/.github/workflows/rerun-pr-checks.yml
@@ -26,9 +26,12 @@ jobs:
 
     # Kiota Abstractions needs to be released first for PR checks to pass
     # We delay before re-running checks to ensure Abstractions is already released
+    # We sleep before re-running checks to ensure the status checks have time to update (https://github.com/cli/cli/pull/2279#discussion_r513610296)
+    # Fetching checks on recently created branches can return a false "no required checks reported on the ... branch" error
     - name: Delay and re-run checks
       run: |
-        needsRerun=$(gh pr checks $PR_URL --required --json bucket --jq '.[] | select(.bucket != "pass") | .bucket')
+        sleep 30
+        needsRerun=$(gh pr checks $PR_URL --required --watch --json bucket --jq '.[] | select(.bucket != "pass") | .bucket')
         if [[ $needsRerun ]]; then
           sleep 300
           gh pr checks $PR_URL --required --json link --jq .[].link | grep -oP '/runs/\K\d+' | { read runId; gh run rerun $runId; }

--- a/packages/bundle/README.md
+++ b/packages/bundle/README.md
@@ -24,17 +24,8 @@ run `composer require microsoft/kiota-bundle` or add the following to your `comp
 
 ## Contributing
 
-This project welcomes contributions and suggestions.  Most contributions require you to agree to a
-Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
-the rights to use your contribution. For details, visit https://cla.opensource.microsoft.com.
-
-When you submit a pull request, a CLA bot will automatically determine whether you need to provide
-a CLA and decorate the PR appropriately (e.g., status check, comment). Simply follow the instructions
-provided by the bot. You will only need to do this once across all repos using our CLA.
-
-This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
-For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
-contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+This project welcomes contributions and suggestions. Issues and pull requests should be made against the [kiota-php](https://github.com/microsoft/kiota-php/) repository.
+This repository is only used for releases.
 
 ## Trademarks
 

--- a/packages/http/guzzle/.github/workflows/create-release.yml
+++ b/packages/http/guzzle/.github/workflows/create-release.yml
@@ -21,6 +21,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Get lib version and set environment variable
+      id: get-version
       run: |
         VERSION=$(grep 'VERSION' src/Constants.php |  grep -oE '[0-9]+\.[0-9]+\.([0-9]+|[0-9]+-[a-z]+)')
         echo "VERSION=$VERSION" >> $GITHUB_ENV

--- a/packages/http/guzzle/.github/workflows/rerun-pr-checks.yml
+++ b/packages/http/guzzle/.github/workflows/rerun-pr-checks.yml
@@ -26,9 +26,12 @@ jobs:
 
     # Kiota Abstractions needs to be released first for PR checks to pass
     # We delay before re-running checks to ensure Abstractions is already released
+    # We sleep before re-running checks to ensure the status checks have time to update (https://github.com/cli/cli/pull/2279#discussion_r513610296)
+    # Fetching checks on recently created branches can return a false "no required checks reported on the ... branch" error
     - name: Delay and re-run checks
       run: |
-        needsRerun=$(gh pr checks $PR_URL --required --json bucket --jq '.[] | select(.bucket != "pass") | .bucket')
+        sleep 30
+        needsRerun=$(gh pr checks $PR_URL --required --watch --json bucket --jq '.[] | select(.bucket != "pass") | .bucket')
         if [[ $needsRerun ]]; then
           sleep 300
           gh pr checks $PR_URL --required --json link --jq .[].link | grep -oP '/runs/\K\d+' | { read runId; gh run rerun $runId; }

--- a/packages/serialization/form/.github/workflows/create-release.yml
+++ b/packages/serialization/form/.github/workflows/create-release.yml
@@ -21,6 +21,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Get lib version and set environment variable
+      id: get-version
       run: |
         VERSION=$(grep 'VERSION' src/Constants.php |  grep -oE '[0-9]+\.[0-9]+\.([0-9]+|[0-9]+-[a-z]+)')
         echo "VERSION=$VERSION" >> $GITHUB_ENV

--- a/packages/serialization/form/.github/workflows/rerun-pr-checks.yml
+++ b/packages/serialization/form/.github/workflows/rerun-pr-checks.yml
@@ -26,9 +26,12 @@ jobs:
 
     # Kiota Abstractions needs to be released first for PR checks to pass
     # We delay before re-running checks to ensure Abstractions is already released
+    # We sleep before re-running checks to ensure the status checks have time to update (https://github.com/cli/cli/pull/2279#discussion_r513610296)
+    # Fetching checks on recently created branches can return a false "no required checks reported on the ... branch" error
     - name: Delay and re-run checks
       run: |
-        needsRerun=$(gh pr checks $PR_URL --required --json bucket --jq '.[] | select(.bucket != "pass") | .bucket')
+        sleep 30
+        needsRerun=$(gh pr checks $PR_URL --required --watch --json bucket --jq '.[] | select(.bucket != "pass") | .bucket')
         if [[ $needsRerun ]]; then
           sleep 300
           gh pr checks $PR_URL --required --json link --jq .[].link | grep -oP '/runs/\K\d+' | { read runId; gh run rerun $runId; }

--- a/packages/serialization/json/.github/workflows/create-release.yml
+++ b/packages/serialization/json/.github/workflows/create-release.yml
@@ -21,6 +21,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Get lib version and set environment variable
+      id: get-version
       run: |
         VERSION=$(grep 'VERSION' src/Constants.php |  grep -oE '[0-9]+\.[0-9]+\.([0-9]+|[0-9]+-[a-z]+)')
         echo "VERSION=$VERSION" >> $GITHUB_ENV

--- a/packages/serialization/json/.github/workflows/rerun-pr-checks.yml
+++ b/packages/serialization/json/.github/workflows/rerun-pr-checks.yml
@@ -26,9 +26,12 @@ jobs:
 
     # Kiota Abstractions needs to be released first for PR checks to pass
     # We delay before re-running checks to ensure Abstractions is already released
+    # We sleep before re-running checks to ensure the status checks have time to update (https://github.com/cli/cli/pull/2279#discussion_r513610296)
+    # Fetching checks on recently created branches can return a false "no required checks reported on the ... branch" error
     - name: Delay and re-run checks
       run: |
-        needsRerun=$(gh pr checks $PR_URL --required --json bucket --jq '.[] | select(.bucket != "pass") | .bucket')
+        sleep 30
+        needsRerun=$(gh pr checks $PR_URL --required --watch --json bucket --jq '.[] | select(.bucket != "pass") | .bucket')
         if [[ $needsRerun ]]; then
           sleep 300
           gh pr checks $PR_URL --required --json link --jq .[].link | grep -oP '/runs/\K\d+' | { read runId; gh run rerun $runId; }

--- a/packages/serialization/multipart/.github/workflows/create-release.yml
+++ b/packages/serialization/multipart/.github/workflows/create-release.yml
@@ -21,6 +21,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Get lib version and set environment variable
+      id: get-version
       run: |
         VERSION=$(grep 'VERSION' src/Constants.php |  grep -oE '[0-9]+\.[0-9]+\.([0-9]+|[0-9]+-[a-z]+)')
         echo "VERSION=$VERSION" >> $GITHUB_ENV

--- a/packages/serialization/multipart/.github/workflows/rerun-pr-checks.yml
+++ b/packages/serialization/multipart/.github/workflows/rerun-pr-checks.yml
@@ -26,9 +26,12 @@ jobs:
 
     # Kiota Abstractions needs to be released first for PR checks to pass
     # We delay before re-running checks to ensure Abstractions is already released
+    # We sleep before re-running checks to ensure the status checks have time to update (https://github.com/cli/cli/pull/2279#discussion_r513610296)
+    # Fetching checks on recently created branches can return a false "no required checks reported on the ... branch" error
     - name: Delay and re-run checks
       run: |
-        needsRerun=$(gh pr checks $PR_URL --required --json bucket --jq '.[] | select(.bucket != "pass") | .bucket')
+        sleep 30
+        needsRerun=$(gh pr checks $PR_URL --required --watch --json bucket --jq '.[] | select(.bucket != "pass") | .bucket')
         if [[ $needsRerun ]]; then
           sleep 300
           gh pr checks $PR_URL --required --json link --jq .[].link | grep -oP '/runs/\K\d+' | { read runId; gh run rerun $runId; }

--- a/packages/serialization/text/.github/workflows/create-release.yml
+++ b/packages/serialization/text/.github/workflows/create-release.yml
@@ -21,6 +21,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Get lib version and set environment variable
+      id: get-version
       run: |
         VERSION=$(grep 'VERSION' src/Constants.php |  grep -oE '[0-9]+\.[0-9]+\.([0-9]+|[0-9]+-[a-z]+)')
         echo "VERSION=$VERSION" >> $GITHUB_ENV

--- a/packages/serialization/text/.github/workflows/rerun-pr-checks.yml
+++ b/packages/serialization/text/.github/workflows/rerun-pr-checks.yml
@@ -26,9 +26,12 @@ jobs:
 
     # Kiota Abstractions needs to be released first for PR checks to pass
     # We delay before re-running checks to ensure Abstractions is already released
+    # We sleep before re-running checks to ensure the status checks have time to update (https://github.com/cli/cli/pull/2279#discussion_r513610296)
+    # Fetching checks on recently created branches can return a false "no required checks reported on the ... branch" error
     - name: Delay and re-run checks
       run: |
-        needsRerun=$(gh pr checks $PR_URL --required --json bucket --jq '.[] | select(.bucket != "pass") | .bucket')
+        sleep 30
+        needsRerun=$(gh pr checks $PR_URL --required --watch --json bucket --jq '.[] | select(.bucket != "pass") | .bucket')
         if [[ $needsRerun ]]; then
           sleep 300
           gh pr checks $PR_URL --required --json link --jq .[].link | grep -oP '/runs/\K\d+' | { read runId; gh run rerun $runId; }


### PR DESCRIPTION
Fixes 
- failing GitHub release workflow - https://github.com/microsoft/kiota-abstractions-php/actions/runs/13375032942/job/37352240251. Adds the step ID for the GitHub output to reference
- failing PR checks re-run [job](https://github.com/microsoft/kiota-authentication-phpleague-php/actions/runs/13374984196/job/37352075756) due to limitation in API failing to report checks immediately after a new branch is created. We sleep first then add a `--wait` for checks to finish running