### PR TITLE
Require php-http/promise 1.3.0 to be compatible with PHP 8.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -77,7 +77,7 @@
         "league/oauth2-client": "^2.6.1",
         "open-telemetry/sdk": "^1.0.0",
         "php": "^7.4 || ^8.0",
-        "php-http/promise": "~1.2.0",
+        "php-http/promise": "~1.3.0",
         "psr/http-message": "^1.1 || ^2.0",
         "ramsey/uuid": "^4.2.3",
         "stduritemplate/stduritemplate": "^0.0.53 || ^0.0.54 || ^0.0.55 || ^0.0.56 || ^0.0.57 || ^0.0.59 || ^1.0.0 || ^2.0.0"


### PR DESCRIPTION
php-http/promise version 1.3.1 fixed compatibility issues with PHP 8.4. This pull request updates composer.json to allow installing this version of the php-http/promise library