### PR TITLE
Enhance ParseNodeFromStringTrait to handle fractional seconds in serialization

### DIFF
--- a/packages/abstractions/src/Serialization/ParseNodeFromStringTrait.php
+++ b/packages/abstractions/src/Serialization/ParseNodeFromStringTrait.php
@@ -14,13 +14,8 @@ trait ParseNodeFromStringTrait
     /**
      * @throws Exception
      */
-    private function parseDateIntervalFromString(?string $value): DateInterval
+    private function parseDateIntervalFromString(string $value): DateInterval
     {
-        // Provide a default zero interval if null or empty string
-        if ($value === null || $value === '') {
-            $value = 'P0D';
-        }
-
         $negativeValPosition = strpos($value, '-');
         $invert = 0;
         $str = $value;
@@ -33,6 +28,10 @@ trait ParseNodeFromStringTrait
 
         // Strip fractional seconds, e.g., PT33.48S => PT33S
         $str = preg_replace('/(\d+)\.\d+S$/', '$1S', $str);
+        
+        if (is_null($str) || is_array($str)) {
+            throw new Exception("Invalid DateInterval string: '$value'");
+        }
 
         $dateInterval = new DateInterval($str);
         $dateInterval->invert = $invert;

--- a/packages/abstractions/src/Serialization/ParseNodeFromStringTrait.php
+++ b/packages/abstractions/src/Serialization/ParseNodeFromStringTrait.php
@@ -29,7 +29,7 @@ trait ParseNodeFromStringTrait
         // Strip fractional seconds, e.g., PT33.48S => PT33S
         $str = preg_replace('/(\d+)\.\d+S$/', '$1S', $str);
         
-        if (is_null($str) || is_array($str)) {
+        if (is_null($str)) {
             throw new Exception("Invalid DateInterval string: '$value'");
         }
 

--- a/packages/abstractions/src/Serialization/ParseNodeFromStringTrait.php
+++ b/packages/abstractions/src/Serialization/ParseNodeFromStringTrait.php
@@ -14,23 +14,29 @@ trait ParseNodeFromStringTrait
     /**
      * @throws Exception
      */
-    private function parseDateIntervalFromString(string $value): DateInterval
+    private function parseDateIntervalFromString(?string $value): DateInterval
     {
+        // Provide a default zero interval if null or empty string
+        if ($value === null || $value === '') {
+            $value = 'P0D';
+        }
+
         $negativeValPosition = strpos($value, '-');
         $invert = 0;
         $str = $value;
+
         if ($negativeValPosition !== false && $negativeValPosition === 0) {
             // Invert the interval
             $invert = 1;
             $str = substr($value, 1);
         }
-        // Strip fractional seconds, such as PT33.48S
+
+        // Strip fractional seconds, e.g., PT33.48S => PT33S
         $str = preg_replace('/(\d+)\.\d+S$/', '$1S', $str);
-        if(strlen($str) === 0) {
-            throw new Exception("Invalid DateInterval string: '$value'");
-        }
+
         $dateInterval = new DateInterval($str);
         $dateInterval->invert = $invert;
+
         return $dateInterval;
     }
 }

--- a/packages/abstractions/src/Serialization/ParseNodeFromStringTrait.php
+++ b/packages/abstractions/src/Serialization/ParseNodeFromStringTrait.php
@@ -24,6 +24,8 @@ trait ParseNodeFromStringTrait
             $invert = 1;
             $str = substr($value, 1);
         }
+        // Strip fractional seconds, such as PT33.48S
+        $str = preg_replace('/(\d+)\.\d+S$/', '$1S', $str);
         $dateInterval = new DateInterval($str);
         $dateInterval->invert = $invert;
         return $dateInterval;

--- a/packages/abstractions/src/Serialization/ParseNodeFromStringTrait.php
+++ b/packages/abstractions/src/Serialization/ParseNodeFromStringTrait.php
@@ -26,6 +26,9 @@ trait ParseNodeFromStringTrait
         }
         // Strip fractional seconds, such as PT33.48S
         $str = preg_replace('/(\d+)\.\d+S$/', '$1S', $str);
+        if(strlen($str) === 0) {
+            throw new Exception("Invalid DateInterval string: '$value'");
+        }
         $dateInterval = new DateInterval($str);
         $dateInterval->invert = $invert;
         return $dateInterval;

--- a/packages/abstractions/tests/Serialization/ParseNodeTraitTest.php
+++ b/packages/abstractions/tests/Serialization/ParseNodeTraitTest.php
@@ -63,6 +63,28 @@ class ParseNodeTraitTest extends TestCase
         $this->assertEquals(33, $di->s, 'Seconds fractional part should be stripped to 33 seconds');
     }
 
+    public function testEmptyStringReturnsZeroInterval(): void
+    {
+        $parseNode = new class
+        {
+            use ParseNodeFromStringTrait {
+                parseDateIntervalFromString as public;
+            }
+        };
+
+        $di = $parseNode->parseDateIntervalFromString('');
+
+        $this->assertInstanceOf(DateInterval::class, $di);
+        $this->assertEquals(0, $di->y, 'Years should be 0');
+        $this->assertEquals(0, $di->m, 'Months should be 0');
+        $this->assertEquals(0, $di->d, 'Days should be 0');
+        $this->assertEquals(0, $di->h, 'Hours should be 0');
+        $this->assertEquals(0, $di->i, 'Minutes should be 0');
+        $this->assertEquals(0, $di->s, 'Seconds should be 0');
+        $this->assertEquals(0, $di->invert, 'Invert flag should be 0');
+    }
+
+
     public function testNegativeIntervalKeepsInvertFlag(): void
     {
         $parseNode = new class

--- a/packages/abstractions/tests/Serialization/ParseNodeTraitTest.php
+++ b/packages/abstractions/tests/Serialization/ParseNodeTraitTest.php
@@ -32,4 +32,63 @@ class ParseNodeTraitTest extends TestCase
 
         $this->assertEquals($dateInterval, $value);
     }
+
+    public function testStripsFractionalSecondsSecondsOnly(): void
+    {
+        $parseNode = new class
+        {
+            use ParseNodeFromStringTrait {
+                parseDateIntervalFromString as public;
+            }
+        };
+        $di = $parseNode->parseDateIntervalFromString('PT33.48S');
+
+        $this->assertInstanceOf(\DateInterval::class, $di);
+        $this->assertEquals(33, $di->s, 'Fractional seconds should be stripped to 33 seconds');
+        $this->assertEquals(0, $di->i, 'No minutes expected');
+    }
+
+    public function testStripsFractionalSecondsWithMinutes(): void
+    {
+        $parseNode = new class
+        {
+            use ParseNodeFromStringTrait {
+                parseDateIntervalFromString as public;
+            }
+        };
+        $di = $parseNode->parseDateIntervalFromString('PT1M33.48S');
+
+        $this->assertInstanceOf(\DateInterval::class, $di);
+        $this->assertEquals(1, $di->i, 'Minutes should be preserved (1 minute)');
+        $this->assertEquals(33, $di->s, 'Seconds fractional part should be stripped to 33 seconds');
+    }
+
+    public function testNegativeIntervalKeepsInvertFlag(): void
+    {
+        $parseNode = new class
+        {
+            use ParseNodeFromStringTrait {
+                parseDateIntervalFromString as public;
+            }
+        };
+        $di = $parseNode->parseDateIntervalFromString('-PT33.48S');
+
+        $this->assertInstanceOf(\DateInterval::class, $di);
+        $this->assertEquals(33, $di->s);
+        $this->assertEquals(1, $di->invert, 'Negative intervals should set invert = 1');
+    }
+
+    public function testDoesNotModifyValidWholeSecondString(): void
+    {
+        $parseNode = new class
+        {
+            use ParseNodeFromStringTrait {
+                parseDateIntervalFromString as public;
+            }
+        };
+        $di = $parseNode->parseDateIntervalFromString('PT12S');
+
+        $this->assertEquals(12, $di->s);
+        $this->assertEquals(0, $di->invert);
+    }
 }

--- a/packages/abstractions/tests/Serialization/ParseNodeTraitTest.php
+++ b/packages/abstractions/tests/Serialization/ParseNodeTraitTest.php
@@ -63,27 +63,6 @@ class ParseNodeTraitTest extends TestCase
         $this->assertEquals(33, $di->s, 'Seconds fractional part should be stripped to 33 seconds');
     }
 
-    public function testEmptyStringReturnsZeroInterval(): void
-    {
-        $parseNode = new class
-        {
-            use ParseNodeFromStringTrait {
-                parseDateIntervalFromString as public;
-            }
-        };
-
-        $di = $parseNode->parseDateIntervalFromString('');
-
-        $this->assertInstanceOf(DateInterval::class, $di);
-        $this->assertEquals(0, $di->y, 'Years should be 0');
-        $this->assertEquals(0, $di->m, 'Months should be 0');
-        $this->assertEquals(0, $di->d, 'Days should be 0');
-        $this->assertEquals(0, $di->h, 'Hours should be 0');
-        $this->assertEquals(0, $di->i, 'Minutes should be 0');
-        $this->assertEquals(0, $di->s, 'Seconds should be 0');
-        $this->assertEquals(0, $di->invert, 'Invert flag should be 0');
-    }
-
 
     public function testNegativeIntervalKeepsInvertFlag(): void
     {


### PR DESCRIPTION
Added regex to strip fractional seconds from interval strings.

This is caused when a value like PT33.48S is passed to the `parseDateIntervalFromString()` function, and causes a fatal error:
```
Unknown or bad format (PT33.48S) #0 /opt/vendor/microsoft/kiota-abstractions/src/Serialization
ParseNodeFromStringTrait.php(27): DateInterval->__construct('PT33.48S') 
#1 /opt/vendor/microsoft/kiota-serialization-json/src/JsonParseNode.php(296):
\Kiota\Serialization\Json\JsonParseNode->parseDateIntervalFromString('PT33.48S')
```