### PR TITLE
Remove abandoned doctrine/annotations package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,6 @@
 		}
 	],
     "require": {
-        "doctrine/annotations": "^1.13 || ^2.0",
         "ext-json": "*",
         "ext-openssl": "*",
         "ext-zlib": "*",

--- a/packages/abstractions/composer.json
+++ b/packages/abstractions/composer.json
@@ -24,7 +24,6 @@
 	"require": {
 		"php": "^8.2",
 		"php-http/promise": "~1.2.0",
-		"doctrine/annotations": "^1.13 || ^2.0",
 		"open-telemetry/sdk": "^1.0.0",
 		"ramsey/uuid": "^4.2.3",
 		"stduritemplate/stduritemplate": "^0.0.53 || ^0.0.54 || ^0.0.55 || ^0.0.56 || ^0.0.57 || ^0.0.59 || ^1.0.0 || ^2.0.0",

--- a/packages/abstractions/src/QueryParameter.php
+++ b/packages/abstractions/src/QueryParameter.php
@@ -8,18 +8,18 @@
 
 namespace Microsoft\Kiota\Abstractions;
 
+use Attribute;
+
 /**
  * Class QueryParameter
  *
- * Attribute/annotation for query parameter class  properties
+ * Attribute for query parameter class properties
  *
- * @Annotation
- * @Target("PROPERTY")
- * @NamedArgumentConstructor
  * @package Microsoft\Kiota\Abstractions
  * @copyright 2022 Microsoft Corporation
  * @license https://opensource.org/licenses/MIT MIT License
  */
+#[Attribute(Attribute::TARGET_PROPERTY)]
 class QueryParameter
 {
     /**

--- a/packages/abstractions/src/RequestInformation.php
+++ b/packages/abstractions/src/RequestInformation.php
@@ -4,7 +4,6 @@ namespace Microsoft\Kiota\Abstractions;
 use DateInterval;
 use DateTime;
 use DateTimeInterface;
-use Doctrine\Common\Annotations\AnnotationReader;
 use Exception;
 use InvalidArgumentException;
 use Microsoft\Kiota\Abstractions\Serialization\Parsable;
@@ -47,7 +46,6 @@ class RequestInformation {
     private static string $binaryContentType = 'application/octet-stream';
     /** @var non-empty-string $contentTypeHeader */
     public static string $contentTypeHeader = 'Content-Type';
-    private static AnnotationReader $annotationReader;
     /**
      * @var ObservabilityOptions $observabilityOptions
      */
@@ -62,8 +60,6 @@ class RequestInformation {
         $this->headers = new RequestHeaders();
         $this->observabilityOptions = $observabilityOptions ?? new ObservabilityOptions();
         $this->tracer = $this->observabilityOptions::getTracer();
-        // Init annotation utils
-        self::$annotationReader = new AnnotationReader();
     }
 
     /** Gets the URI of the request.
@@ -314,10 +310,12 @@ class RequestInformation {
         $reflectionClass = new \ReflectionClass($queryParameters);
         foreach ($reflectionClass->getProperties() as $classProperty) {
             $propertyValue = $classProperty->getValue($queryParameters);
-            $propertyAnnotation = self::$annotationReader->getPropertyAnnotation($classProperty, QueryParameter::class);
+            $attribute = $classProperty->getAttributes(QueryParameter::class);
             if ($propertyValue) {
-                if ($propertyAnnotation) {
-                    $this->queryParameters[$propertyAnnotation->name] = $propertyValue;
+                if (!empty($attribute)) {
+                    /** @var QueryParameter $queryParamInstance */
+                    $queryParamInstance = $attribute[0]->newInstance();
+                    $this->queryParameters[$queryParamInstance->name] = $propertyValue;
                     continue;
                 }
                 $this->queryParameters[$classProperty->name] = $propertyValue;

--- a/packages/abstractions/tests/RequestInformationTest.php
+++ b/packages/abstractions/tests/RequestInformationTest.php
@@ -219,8 +219,8 @@ class RequestInformationTest extends TestCase {
 class TestQueryParameter {
     /**
      * @var string[]|null
-     * @QueryParameter("%24select")
      */
+    #[QueryParameter("%24select")]
     public ?array $select = null;
     public bool $count = false;
     public int $top = 10; // no annotation


### PR DESCRIPTION
Attempt to solve #73 and remove the dependency on annotations. Since this package only supports PHP 8.2+ now, this should be safe.